### PR TITLE
Add files to RPM

### DIFF
--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -54,6 +54,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.ini
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.json
+%config(noreplace) %{_sysconfdir}/xdmod/rest.d/akrr.json
+%config(noreplace) %{_sysconfdir}/xdmod/rest.d/app_kernel.json
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 
 %changelog


### PR DESCRIPTION
Update RPM spec file to include new configuration files.

## Description

Updates RPM spec file to include new configuration files that don't match the existing pattern for configuration files.

## Motivation and Context

If these files are to be included in the RPM, they need to be included in the RPM spec file.

## Tests performed

No tests performed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
