### PR TITLE
update composer and php-codesniffer dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
         }
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.8.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,22 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a8270b84d113bb7369c6288a7a93cb25",
-    "content-hash": "f3a86341f28fbceb4e8194af1f27af91",
+    "content-hash": "dfa1277eff592c0413ed4473395b99f9",
     "packages": [],
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b"
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1bcdf03b068a530ac1962ce671dead356eeba43b",
-                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/86dd55a522238211f9f3631e3361703578941d9a",
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a",
                 "shasum": ""
             },
             "require": {
@@ -84,7 +83,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-04-03 22:58:34"
+            "time": "2017-02-02T03:30:00+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Description
Update lock file with php-codesniffer dependency stuck to a specific version, bring all repositories in line with same version

## Motivation and Context
Make sure all composer.lock files match composer 1.3.x version

## Tests performed
ran composer install without errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)