### PR TITLE
Travis: Cache npm cache directory instead of node_modules directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 # Add dependency directories to the Travis cache
 cache:
     directories:
-        - node_modules
+        - $HOME/.npm
         - $HOME/.composer/cache
         - /tmp/pear/cache
 


### PR DESCRIPTION
## Description
See ubccr/xdmod-supremm#34.

## Motivation and Context
See ubccr/xdmod-supremm#34.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
