### PR TITLE
Adding ETL related files for the appkernels module

### DIFF
--- a/build.json
+++ b/build.json
@@ -38,7 +38,8 @@
             "configuration/roles.json": "roles.d/appkernels.json",
             "configuration/setup.json": "setup.d/appkernels.json",
             "configuration/rest.d": "rest.d",
-            "configuration/assets.d": "assets.d"
+            "configuration/assets.d": "assets.d",
+            "configuration/modules.d/appkernels.json": "modules.d/appkernels.json"
         },
         "etc/crond": {
             "configuration/cron.conf": "xdmod-appkernels"

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -51,7 +51,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/xdmod/
 %{_datadir}/xdmod/
 %{_docdir}/%{name}-%{version}__PRERELEASE__/
-%{_docdir}/%{name}-%{version}/
 %{_sysconfdir}/xdmod/modules.d/appkernels.json
 
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.ini

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -52,10 +52,13 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 %{_docdir}/%{name}-%{version}__PRERELEASE__/
 %{_docdir}/%{name}-%{version}/
-%{_sysconfdir}/modules.d/appkernels.json
+%{_sysconfdir}/xdmod/modules.d/appkernels.json
 
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.ini
-%config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.json
+%config(noreplace) %{_sysconfdir}/xdmod/assets.d/appkernels*.json
+%config(noreplace) %{_sysconfdir}/xdmod/internal_dashboard.d/appkernels*.json
+%config(noreplace) %{_sysconfdir}/xdmod/roles.d/appkernels*.json
+%config(noreplace) %{_sysconfdir}/xdmod/setup.d/appkernels*.json
 %config(noreplace) %{_sysconfdir}/xdmod/rest.d/akrr.json
 %config(noreplace) %{_sysconfdir}/xdmod/rest.d/app_kernel.json
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -51,6 +51,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/xdmod/
 %{_datadir}/xdmod/
 %{_docdir}/%{name}-%{version}__PRERELEASE__/
+%{_docdir}/%{name}-%{version}/
+%{_sysconfdir}/modules.d/appkernels.json
 
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.ini
 %config(noreplace) %{_sysconfdir}/xdmod/*.d/appkernels.json


### PR DESCRIPTION
## Description
Added the modules.d/appkernels.json file to the file_maps section of
  build.json


## Motivation and Context
So that the new file would be included in the packaged module / installed when 'install' is executed. 

## Tests performed
Manual test performed: 
  - modified build.json w/ the new entry in file_maps/etc
  - executed: \<xdmod_dir\>/open_xdmod/build_scripts/build_package --module appkernels --skip-assets --verbose
  - cd \<xdmod_dir\>/open_xdmod/build
  - tar xvzf xdmod-appkernels-6.7.0.tar.gz
  - ls -alh configuration/modules.d/appkernels.json
    - ensure that the file exists
  - cat configuration/modules.d/appkernels.json
    - ensure that it is a json file and that it contains the correct information
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
