### PR TITLE
Fix App Kernels tab in internal dashboard

### DIFF
--- a/html/internal_dashboard/js/Arr/AppKernelDashboardPanel.js
+++ b/html/internal_dashboard/js/Arr/AppKernelDashboardPanel.js
@@ -62,6 +62,9 @@ XDMoD.Arr.AppKernelDashboardPanel = Ext.extend(Ext.ux.GroupTabPanel, {
 
 
     },
+    adjustBodyWidth: function (w) {
+        return w - this.tabWidth - 2;
+    },
     listeners: {
         'tabchange': {
             fn: function (tabpanel,tab) {


### PR DESCRIPTION
The layout of the tab body on the "App Kernels" tab on the internal dashboard is wrong on firefox linux.

![old jpg](https://user-images.githubusercontent.com/5342179/38880389-996795aa-4233-11e8-82bd-94fea286d799.png)

![new jpg](https://user-images.githubusercontent.com/5342179/38880398-9e2083a4-4233-11e8-8d12-a1d8f123aa42.png)
