### PR TITLE
remove eslintjson.rc from rpm builds

### DIFF
--- a/build.json
+++ b/build.json
@@ -12,6 +12,11 @@
             "#/\\.#"
         ]
     },
+    "commands": {
+        "pre_build": [
+            "find . -type f -name .eslintrc.json -delete"
+        ]
+    },
     "file_maps": {
         "data": [
             "appkernel",


### PR DESCRIPTION
should remove the .eslintrc.json from the build so that the rpm can co-exist peacefully with xdmod.