### PR TITLE
Adding a linker.d file for AppKernels

### DIFF
--- a/build.json
+++ b/build.json
@@ -41,7 +41,8 @@
             "configuration/setup.json": "setup.d/appkernels.json",
             "configuration/rest.d": "rest.d",
             "configuration/assets.d": "assets.d",
-            "configuration/modules.d/appkernels.json": "modules.d/appkernels.json"
+            "configuration/modules.d/appkernels.json": "modules.d/appkernels.json",
+            "configuration/linker.d/appkernels.json": "linker.d/appkernels.json"
         },
         "etc/crond": {
             "configuration/cron.conf": "xdmod-appkernels"

--- a/configuration/linker.d/appkernels.json
+++ b/configuration/linker.d/appkernels.json
@@ -1,0 +1,5 @@
+{
+  "+include_dirs": [
+    "classes/AppKernel"
+  ]
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This new file contains the AppKernels specific entry that was removed from
XDMoD's `linker.json` file.


## Motivation and Context
So that this module will work w/ XDMoD's `linker.php` when installed.

## Tests performed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
