### PR TITLE
Removing unneeded `print` statement

### DIFF
--- a/classes/AppKernel/PerformanceMap.php
+++ b/classes/AppKernel/PerformanceMap.php
@@ -210,8 +210,6 @@ class PerformanceMap
 
         $message.="</table>\n";
         $message.='The status code is linked to full report of the last run.<br/><br/>';
-        print($message);
-
 
         $totalColumns=1+count($rec_dates)+1;
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This print statement was causing the `App Kernels` -> `Reports` -> `Send X
Report` functionality to lock up XDMoD ( Due to HTML being returned which made
it no longer valid json )


## Motivation and Context
Not locking up XDMoD == good

## Tests performed
Manual Testing was performed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
