### PR TITLE
Updates to allow for PO usage

### DIFF
--- a/classes/Rest/Controllers/AppKernelControllerProvider.php
+++ b/classes/Rest/Controllers/AppKernelControllerProvider.php
@@ -1585,9 +1585,6 @@ or "Show Details of Successful Tasks" options to see details on tasks';
      * Retrieves the raw numeric values for the AppKernel Performance Map. This endpoint provides
      * the data for `CenterReportCardPortlet.js`
      *
-     * **NOTE:** This function will throw an UnauthorizedException if the user making the request
-     * does not have the Center Director or Center Staff acl.
-     *
      * @param Request     $request
      * @param Application $app
      * @return JsonResponse
@@ -1598,10 +1595,6 @@ or "Show Details of Successful Tasks" options to see details on tasks';
     {
         $user = $this->authorize($request);
 
-        // We need to ensure that only Center Director / Center Staff users are authorized to
-        // utilize this endpoint. Note, we do not utilize the `requirements` parameter of the above
-        // `authorize` call because it utilizes `XDUser::hasAcls` which only checks if the user has
-        // *all* of the supplied acls, not any of the supplied acls.
         $startDate = $this->getStringParam($request, 'start_date', true);
         if ($startDate !== null) {
             $startDate = new \DateTime($startDate);

--- a/classes/Rest/Controllers/AppKernelControllerProvider.php
+++ b/classes/Rest/Controllers/AppKernelControllerProvider.php
@@ -1602,10 +1602,6 @@ or "Show Details of Successful Tasks" options to see details on tasks';
         // utilize this endpoint. Note, we do not utilize the `requirements` parameter of the above
         // `authorize` call because it utilizes `XDUser::hasAcls` which only checks if the user has
         // *all* of the supplied acls, not any of the supplied acls.
-        if ( ! ( $user->hasAcl(ROLE_ID_CENTER_DIRECTOR) ||  $user->hasAcl(ROLE_ID_CENTER_STAFF) ) ) {
-            throw  new UnauthorizedHttpException('xdmod', "Unable to complete action. User is not authorized.");
-        }
-
         $startDate = $this->getStringParam($request, 'start_date', true);
         if ($startDate !== null) {
             $startDate = new \DateTime($startDate);
@@ -1628,13 +1624,16 @@ or "Show Details of Successful Tasks" options to see details on tasks';
 
         $data = array();
         try {
-            $perfMap = new \AppKernel\PerformanceMap(array(
-                'start_date' => $startDate,
-                'end_date' => $endDate,
-                'resource' => array('data' => $user->getResources()),
-                'appKer' => $appKernels,
-                'problemSize' => $problemSizes
-            ));
+            $options = array(
+                    'start_date' => $startDate,
+                    'end_date' => $endDate,
+                    'appKer' => $appKernels,
+                    'problemSize' => $problemSizes
+            );
+            if (!$user->hasAcl(ROLE_ID_PROGRAM_OFFICER)) {
+                $options['resource'] = array('data' => $user->getResources());
+            }
+            $perfMap = new \AppKernel\PerformanceMap($options);
 
             // The columns that we're going to be retrieving from the PerformanceMap and ultimately
             // returning to the requester.


### PR DESCRIPTION
## Description
This functionality was originally added for OpenXDMoD and as such did not take into
account that PO would also be utilizing this endpoint. Logic has been added to the
 options building that defaults to not restricting the resources
returned, but if the user does not have  then they are restricted to seeing only
the resources they have access to.

## Motivation and Context
To allow PO's to utilize this rest endpoint.

## Tests performed
Manual testing on my dev port

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
