### PR TITLE
Updates to support PHP8

### DIFF
--- a/classes/AppKernel/Arr/Explorer.php
+++ b/classes/AppKernel/Arr/Explorer.php
@@ -381,7 +381,7 @@ class ArrExplorer implements iAppKernelExplorer
     if ( empty($instance) )
       throw new Exception("Empty instance identifier");
     else if ( ! is_numeric($instance) )
-      throw new Exception("Malformed instance identifier '$instanceInfo'");
+      throw new Exception("Malformed instance identifier");
 
     $sql = "select * from akrr_xdmod_instanceinfo where instance_id = $instance";
     $result = $this->_db_akrr->query($sql);

--- a/classes/AppKernel/PerformanceMap.php
+++ b/classes/AppKernel/PerformanceMap.php
@@ -662,7 +662,8 @@ SQL;
             $rec_date = date_format(date_create($row['collected']), 'Y/m/d');
             $resource = $row['resource'];
             $appKer = $row['reporter'];
-            $problemSize = end(explode('.', $row['reporternickname']));
+            $reporterNickName = explode('.', $row['reporternickname']);
+            $problemSize = end($reporterNickName);
             $collected = $row['collected'];
 
             $resource_id = array_key_exists($resource, $this->resource_ids) ? $this->resource_ids[$resource] : null;

--- a/classes/AppKernel/ProblemDetector/AppKernelLevel.php
+++ b/classes/AppKernel/ProblemDetector/AppKernelLevel.php
@@ -52,7 +52,7 @@ class AppKernelLevel
         return $s;
     }
 
-    public function detect(){
+    public function detect($problemsAppKernelLevel){
         $max_days=max(array_keys($this->runStatsAppKernel->NE));
         $all_problems=array();
         $init_max_days=10;

--- a/classes/AppKernel/RunsStats.php
+++ b/classes/AppKernel/RunsStats.php
@@ -66,14 +66,14 @@ class RunsStats
             $this->E[$days]=0;
             $this->NE[$days]=0;
 
-            if($sum_map{$i}==' '){
+            if($sum_map[$i] ==' '){
                 $this->E[$days]++;
             }
             else{
                 $this->NE[$days]++;
-                if($sum_map{$i}=='F')$this->F[$days]++;
-                if($sum_map{$i}=='O')$this->O[$days]++;
-                if($sum_map{$i}=='U')$this->U[$days]++;
+                if($sum_map[$i] =='F')$this->F[$days]++;
+                if($sum_map[$i] =='O')$this->O[$days]++;
+                if($sum_map[$i] =='U')$this->U[$days]++;
             }
             $this->T[$days]++;
 
@@ -105,7 +105,7 @@ class RunsStats
         //Under-performance can be mixed with failure
         for($i=0;$i<strlen($sum_map);$i++){
             $days=strlen($sum_map)-$i;
-            if($sum_map{$i}==='U' && $this->NE[$days]===$this->F[$days]+$this->U[$days]){
+            if($sum_map[$i] ==='U' && $this->NE[$days]===$this->F[$days]+$this->U[$days]){
                 $this->UstreakRuns=$this->F[$days]+$this->U[$days];
                 $this->UstreakDays=$days;
                 break;
@@ -222,12 +222,12 @@ class RunsStats
             for($i=$Ndays-1;$i>=0;$i--){
                 $commondNonEmptyRun=NULL;
                 foreach($sum_map as $s) {
-                    if($s{$i}!=' '){
+                    if($s[$i] !=' '){
                         if($commondNonEmptyRun===NULL){
-                            $commondNonEmptyRun=$s{$i};
+                            $commondNonEmptyRun=$s[$i];
                         }
                         else{
-                            if($commondNonEmptyRun!==$s{$i}){
+                            if($commondNonEmptyRun!==$s[$i]){
                                 $commondNonEmptyRun='Z';
                             }
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates to address PHP8 incompatibilities. Mainly of the "Can only pass variables by-ref" type.  

## Motivation and Context
We want to support PHP8 for XDMoD 11.0. 

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
