### PR TITLE
Adding default argument value for AppKernelLevel::detect

### DIFF
--- a/classes/AppKernel/ProblemDetector/AppKernelLevel.php
+++ b/classes/AppKernel/ProblemDetector/AppKernelLevel.php
@@ -52,7 +52,7 @@ class AppKernelLevel
         return $s;
     }
 
-    public function detect($problemsAppKernelLevel=array()){
+    public function detect($problemsAppKernelLevel = array()){
         $max_days=max(array_keys($this->runStatsAppKernel->NE));
         $all_problems=array();
         $init_max_days=10;

--- a/classes/AppKernel/ProblemDetector/AppKernelLevel.php
+++ b/classes/AppKernel/ProblemDetector/AppKernelLevel.php
@@ -52,7 +52,7 @@ class AppKernelLevel
         return $s;
     }
 
-    public function detect($problemsAppKernelLevel){
+    public function detect($problemsAppKernelLevel=array()){
         $max_days=max(array_keys($this->runStatsAppKernel->NE));
         $all_problems=array();
         $init_max_days=10;

--- a/classes/AppKernel/ProblemDetector/ResourceLevel.php
+++ b/classes/AppKernel/ProblemDetector/ResourceLevel.php
@@ -24,7 +24,7 @@ class ResourceLevel extends AppKernelLevel
         $this->problemSizes=array_keys($runStatsAppKernel->sum_map);
         $this->appKerShortname=$appKerShortname;*/
     }
-    public function detect($problemsAppKernelLevel=array()){
+    public function detect($problemsAppKernelLevel = array()){
         /*AppKernelLevel::detect();
         print "Resource:\n";
         print_r($this->problems);

--- a/classes/AppKernel/ProblemDetector/ResourceLevel.php
+++ b/classes/AppKernel/ProblemDetector/ResourceLevel.php
@@ -24,7 +24,7 @@ class ResourceLevel extends AppKernelLevel
         $this->problemSizes=array_keys($runStatsAppKernel->sum_map);
         $this->appKerShortname=$appKerShortname;*/
     }
-    public function detect($problemsAppKernelLevel){
+    public function detect($problemsAppKernelLevel=array()){
         /*AppKernelLevel::detect();
         print "Resource:\n";
         print_r($this->problems);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added a default value of `array()` for the `$problemsAppKernelLevel` argument of `AppKernelLevel::detect` and it's child class `ResourceLevel`. 

## Motivation and Context
`AppKernelLevel::detect()`'s argument $problemsAppKernelLevel needs to have a default value provided.

## Tests performed
Manual Checking performed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
