### PR TITLE
Replacing jQuery with native JS

### DIFF
--- a/html/.eslintrc.json
+++ b/html/.eslintrc.json
@@ -1,8 +1,7 @@
 {
   "env": {
     "browser": true,
-    "es6": true,
-    "jquery": true
+    "es2018": true
   },
   "globals": {
     "AppKernel": false,

--- a/html/gui/js/modules/app_kernels/AppKernelViewer.js
+++ b/html/gui/js/modules/app_kernels/AppKernelViewer.js
@@ -1,4 +1,4 @@
-/* global XDMoD, CCR, Ext, document, jQuery */
+/* global XDMoD, CCR, Ext, document */
 /**
  * This class contains functionality for the App Kernels tab.
  *

--- a/html/gui/js/modules/app_kernels/AppKernelViewer.js
+++ b/html/gui/js/modules/app_kernels/AppKernelViewer.js
@@ -562,7 +562,7 @@ Ext.extend(XDMoD.Module.AppKernels.AppKernelViewer, XDMoD.PortalModule, {
                     };
 
                     var chartOptions = r.get('hc_jsonstore');
-                    jQuery.extend(true, chartOptions, baseChartOptions);
+                    chartOptions = XDMoD.utils.deepExtend({}, baseChartOptions, chartOptions);
 
                     if (isMenu) {
                         chartOptions.layout.thumbnail = true;

--- a/html/gui/js/modules/app_kernels/AppKernelViewer.js
+++ b/html/gui/js/modules/app_kernels/AppKernelViewer.js
@@ -555,14 +555,13 @@ Ext.extend(XDMoD.Module.AppKernels.AppKernelViewer, XDMoD.PortalModule, {
                             height: height,
                             appkernels: true
                         },
-                        data: [],
                         credits: {
                             enabled: true
                         }
                     };
 
                     var chartOptions = r.get('hc_jsonstore');
-                    chartOptions = XDMoD.utils.deepExtend({}, baseChartOptions, chartOptions);
+                    chartOptions = XDMoD.utils.deepExtend({}, chartOptions, baseChartOptions);
 
                     if (isMenu) {
                         chartOptions.layout.thumbnail = true;

--- a/html/internal_dashboard/js/Arr/ControlRegionsPanel.js
+++ b/html/internal_dashboard/js/Arr/ControlRegionsPanel.js
@@ -741,7 +741,7 @@ XDMoD.Arr.ControlRegionsPanel=Ext.extend(XDMoD.PortalModule,
                     }; //baseChartOptions
 
                     var chartOptions = r.get('hc_jsonstore');
-                    jQuery.extend(true, chartOptions, baseChartOptions);
+                    chartOptions = XDMoD.utils.deepExtend({}, baseChartOptions, chartOptions);
 
                     chartOptions.layout.hovermode = chartOptions.swapXY ? 'y unified' : 'x unified';
                     if (chartOptions.data && chartOptions.data.length !== 0) {

--- a/html/internal_dashboard/js/Arr/ControlRegionsPanel.js
+++ b/html/internal_dashboard/js/Arr/ControlRegionsPanel.js
@@ -734,14 +734,13 @@ XDMoD.Arr.ControlRegionsPanel=Ext.extend(XDMoD.PortalModule,
                             width: isMenu ? CCR.xdmod.ui.thumbWidth * this.chartThumbScale : this.chartWidth * this.chartScale,
                             height: isMenu ? CCR.xdmod.ui.thumbHeight * this.chartThumbScale : this.chartHeight * this.chartScale
                         },
-                        data: [],
                         credits: {
                             enabled: true
                         }
                     }; //baseChartOptions
 
                     var chartOptions = r.get('hc_jsonstore');
-                    chartOptions = XDMoD.utils.deepExtend({}, baseChartOptions, chartOptions);
+                    chartOptions = XDMoD.utils.deepExtend({}, chartOptions, baseChartOptions);
 
                     chartOptions.layout.hovermode = chartOptions.swapXY ? 'y unified' : 'x unified';
                     if (chartOptions.data && chartOptions.data.length !== 0) {

--- a/html/internal_dashboard/js/Arr/SchedulePanel.js
+++ b/html/internal_dashboard/js/Arr/SchedulePanel.js
@@ -133,25 +133,24 @@ XDMoD.Arr.SchedulePanel = Ext.extend(Ext.FormPanel, {
                     scope: this,
                     handler: function () {
                         if (self.getForm().active_record) {
-
-                            var url =  XDMoD.REST.url + '/akrr/tasks/scheduled/' +
-                                self.getForm().active_record.data.task_id +
-                                '?token=' + XDMoD.REST.token;
-
-                            jQuery.ajax({
-                                method: 'DELETE',
-                                url: url,
-                                success: function (data, textStatus, jqXHR) {
-                                    self.fireEvent('task_removed', self.getForm().active_record);
-                                },
-                                error: function (jqXHR, textStatus, errorThrown) {
-                                    console.log('An Exception has occurred: ' + textStatus + ' ' + errorThrown);
+                            fetch(`${XDMoD.REST.url}/akrr/tasks/scheduled/${self.getForm().active_record.data.task_id}?token=${XDMoD.REST.token}`, {
+                                method: 'DELETE'
+                            })
+                            .then((respone) => {
+                                if (!response.ok) {
+                                    throw new Error(`An Exception has occurred: [${response.status}] ${response.statusText}`);
                                 }
+                                return response.json();
+                            })
+                            .then((data) => {
+                                self.fireEvent('task_removed', self.getForm().active_record);
+                            })
+                            .catch((error) => {
+                                console.log(error);
                             });
                         } else {
                             console.log("No record selected for deletion.");
                         }
-
                     }
                 },
                 {

--- a/html/internal_dashboard/js/Arr/SchedulePanel.js
+++ b/html/internal_dashboard/js/Arr/SchedulePanel.js
@@ -136,7 +136,7 @@ XDMoD.Arr.SchedulePanel = Ext.extend(Ext.FormPanel, {
                             fetch(`${XDMoD.REST.url}/akrr/tasks/scheduled/${self.getForm().active_record.data.task_id}?token=${XDMoD.REST.token}`, {
                                 method: 'DELETE'
                             })
-                            .then((respone) => {
+                            .then((response) => {
                                 if (!response.ok) {
                                     throw new Error(`An Exception has occurred: [${response.status}] ${response.statusText}`);
                                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces any jQuery calls with native JavaScript. This PR is dependent on the[ base xdmod jQuery PR](https://github.com/ubccr/xdmod/pull/1756). Most of the changes are with the AppKernel Scheduler displayed in the internal dashboard.

**Note:** There is a bug with creating tasks in the internal dashboard `App Kernels` &#8594; `Schedule` tab. This is the exception thrown when trying to create a task: 
`Call to undefined method Rest\Controllers\AkrrControllerProvider::_parseRestArguments()`
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
jQuery is a large dependency that we use very sparingly.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Ran tests in docker container and viewed changes on xdmod-dev.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
