### PR TITLE
Fix broken title and credits for App Kernel Viewer summary charts

### DIFF
--- a/html/gui/js/modules/app_kernels/AppKernelViewer.js
+++ b/html/gui/js/modules/app_kernels/AppKernelViewer.js
@@ -564,7 +564,7 @@ Ext.extend(XDMoD.Module.AppKernels.AppKernelViewer, XDMoD.PortalModule, {
                     chartOptions = XDMoD.utils.deepExtend({}, chartOptions, baseChartOptions);
 
                     if (isMenu) {
-                        chartOptions.layout.thumbnail = true;
+                        chartOptions.realmOverview = true;
                         chartOptions.layout.margin = {
                             t: 20,
                             l: 5,


### PR DESCRIPTION
Issue found in XDMoD 11.0.0 bug testing

Before:
![Screenshot from 2024-08-13 11-17-06](https://github.com/user-attachments/assets/a01fe8ea-c3d2-441b-8c57-9fa2f1e7efb3)
After:
![Screenshot from 2024-08-13 11-16-56](https://github.com/user-attachments/assets/34f5fa09-9a29-4172-a454-022d26ff49d6)

Fix is visible on my developer port 9004
