### PR TITLE
Fix changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
-## 2024-XX-XX v11.0.0
+## 2024-09-16 v11.0.0
 
 - Enhancements
     - Change charting library to Plotly ([\#106](https://github.com/ubccr/xdmod-appkernels/pull/106))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
-## 2024-08-11 v11.0.0
+## 2024-XX-XX v11.0.0
 
 - Enhancements
-    - Change charting library to Plotly ([\#https://github.com/ubccr/xdmod-appkernels/pull/106](https://github.com/ubccr/xdmod-appkernels/pull/106))
+    - Change charting library to Plotly ([\#106](https://github.com/ubccr/xdmod-appkernels/pull/106))
 - Maintenance / Code Quality
     - Change resource specs query to use new resourcespecs column name ([\#102](https://github.com/ubccr/xdmod-appkernels/pull/102))
     - Updates for compatibility with PHP 7.4 ([\#104](https://github.com/ubccr/xdmod-appkernels/pull/104), [\#110](https://github.com/ubccr/xdmod-appkernels/pull/110))

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -65,9 +65,9 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 
 %changelog
-* Wed Sep 11 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
+* Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
     - Release 11.0.0
-* Tue Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
+* Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
     - Release 10.5.0
 * Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
     - Release 10.0.0


### PR DESCRIPTION
This PR updates the changelog to set the release date for v11.0.0 to the date the RPMs were actually built instead of the date we anticipated they would be built.

It also fixes a link formatting bug.