### PR TITLE
Prep for v11.0.1 development.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
+## v11.0.1 development branch
+
 ## 2024-09-16 v11.0.0
 
 - Enhancements

--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod-appkernels",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,9 +36,9 @@ defaults:
     values:
       layout: "page"
       version: "11.0"
-      sw_version: "11.0.0"
+      sw_version: "11.0.1"
       style: "effervescence"
-      tocversion: "toc"
+      tocversion: "v11_0toc"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
This PR prepares the `xdmod11.0` branch for development of version `11.0.1`. It depends on https://github.com/ubccr/xdmod/pull/1939.