### PR TITLE
Prep for v11.5.0 development.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   rocky8: &rocky8-executor
     docker:
-      - image: tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3
+      - image: tools-ext-01.ccr.xdmod.org/xdmod:x86_64-rockylinux8.9.20231119-v11.0.0-1.0-02
 
 jobs:
   build:
@@ -15,7 +15,7 @@ jobs:
     executor: << parameters.os >>
     environment:
       COMPOSER_ALLOW_SUPERUSER: 1
-      XDMOD_REALMS: 'jobs,storage,cloud'
+      XDMOD_REALMS: 'jobs,storage,cloud,resourcespecifications'
       XDMOD_BRANCH: main
       XDMOD_MODULE_NAME: appkernels
       XDMOD_IS_CORE: yes
@@ -23,23 +23,8 @@ jobs:
       XDMOD_TEST_MODE: << parameters.install-type >>
     steps:
       - run:
-          name: Enable PHP 7.4 module
-          command: dnf module -y reset php && dnf module -y enable php:7.4
-      - run:
-          name: Install PHP 7.4 and PHP module pre-reqs & an updated version of PHP Pear
-          command: dnf install -y php libzip-devel php-pear php-devel
-      - run:
-           name: Install MongoDB Pear module
-           command: yes '' | pecl install mongodb || true
-      - run:
           name: Install Python3
           command: dnf -y install --setopt=tsflags=nodocs python3
-      - run:
-          name: Generate OpenSSL Key
-          command: openssl genrsa -rand /proc/cpuinfo:/proc/dma:/proc/filesystems:/proc/interrupts:/proc/ioports:/proc/uptime 2048 > /etc/pki/tls/private/localhost.key
-      - run:
-          name: Generate Certificate
-          command: /usr/bin/openssl req -new -key /etc/pki/tls/private/localhost.key -x509 -sha256 -days 365 -set_serial $RANDOM -extensions v3_req -out /etc/pki/tls/certs/localhost.crt -subj "/C=XX/L=Default City/O=Default Company Ltd"
       - checkout
       - run:
           name: Create Test Result Directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   rocky8: &rocky8-executor
     docker:
-      - image: tools-ext-01.ccr.xdmod.org/xdmod:x86_64-rockylinux8.9.20231119-v11.0.0-1.0-02
+      - image: tools-ext-01.ccr.xdmod.org/xdmod:x86_64-rockylinux8.9.20231119-v11.0.0-1.0-03
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
+## v11.5.0 development branch
+
 ## 2024-09-16 v11.0.0
 
 - Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
-## v11.5.0 development branch
-
 ## 2024-09-16 v11.0.0
 
 - Enhancements

--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod-appkernels",
-    "version": "11.0.0",
+    "version": "11.5.0",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,10 +35,10 @@ defaults:
       type: "pages"
     values:
       layout: "page"
-      version: "11.0"
-      sw_version: "11.0.0"
+      version: "11.5"
+      sw_version: "11.5.0"
       style: "effervescence"
-      tocversion: "toc"
+      tocversion: "v11_5toc"
 
 # Build settings
 markdown: kramdown

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -11,7 +11,7 @@ Source:        %{name}-%{version}__PRERELEASE__.tar.gz
 BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}__PRERELEASE__-%{release}-XXXXXX)
 BuildArch:     noarch
 BuildRequires: php-cli
-Requires:      xdmod >= 11.0.0, xdmod < 11.1.0
+Requires:      xdmod >= 11.5.0, xdmod < 11.6.0
 
 %description
 This package provides application kernel support for Open XDMoD. The


### PR DESCRIPTION
This PR prepares the `main` branch for development of version `11.5.0`. It depends on https://github.com/ubccr/xdmod/pull/1940.