### PR TITLE
Prepare for v10.5.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
+## XXXX-XX-XX v10.5.1
+
+- Miscellaneous
+    - Updated for compatibility with Open XDMoD 10.5.1
+
 ## 2023-09-11 v10.5.0
 
 - Miscellaneous

--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod-appkernels",
-    "version": "10.5.0",
+    "version": "10.5.1",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -4,7 +4,7 @@ appkernels = "on"
 [appkernels-general]
 
 ; The version number is updated during the upgrade process.
-version = "10.5.0"
+version = "10.5.1"
 
 ; App kernel database and metric configuration.
 [appkernel]

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ description: >
   week) to continuously monitor HPC system performance and reliability from the
   application users' point of view.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://appkernels.xdmod.org" # the base hostname & protocol for your site
+url: "https://appkernels.xdmod.org" # the base hostname & protocol for your site
 github_username: ubccr
 github_url: https://github.com/ubccr/xdmod-appkernels
 xdmod_module_name: Application Kernels
@@ -36,7 +36,7 @@ defaults:
     values:
       layout: "page"
       version: "10.5"
-      sw_version: "10.5.0"
+      sw_version: "10.5.1"
       style: "effervescence"
       tocversion: "toc"
 

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -11,7 +11,7 @@ Source:        %{name}-%{version}__PRERELEASE__.tar.gz
 BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}__PRERELEASE__-%{release}-XXXXXX)
 BuildArch:     noarch
 BuildRequires: php-cli
-Requires:      xdmod >= 10.5.0, xdmod < 10.6.0
+Requires:      xdmod >= 10.5.1, xdmod < 10.6.0
 
 %description
 This package provides application kernel support for Open XDMoD. The


### PR DESCRIPTION
_Note: CentOS 7 tests expected to fail._

Updates for compatibility, see also https://github.com/ubccr/xdmod/pull/1971