### PR TITLE
Update changelog for 11.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
+## XXXX-XX-XX v11.5.0
+
 ## 2024-09-16 v11.0.0
 
 - Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
-## XXXX-XX-XX v11.5.0
-
 ## 2025-03-17 v11.0.1
 
 - Miscellaneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Open XDMoD Application Kernels Change Log
 
 ## XXXX-XX-XX v11.5.0
 
-## XXXX-XX-XX v11.0.1
+## 2025-03-17 v11.0.1
 
 - Miscellaneous
     - Updated for compatibility with Open XDMoD 11.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Open XDMoD Application Kernels Change Log
 
 ## XXXX-XX-XX v11.5.0
 
+## XXXX-XX-XX v11.0.1
+
+- Miscellaneous
+    - Updated for compatibility with Open XDMoD 11.0.1
+
 ## 2024-09-16 v11.0.0
 
 - Enhancements

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "name": "xdmod-appkernels",
     "version": "11.5.0",
-    "release": "1.0",
+    "release": "1",
     "files": {
         "include_paths": [
         ],

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -65,35 +65,37 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 
 %changelog
+* Mon Mar 17 2025 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1
+- Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
-    - Release 11.0.0
+- Release 11.0.0
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
-    - Release 10.5.0
+- Release 10.5.0
 * Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
-    - Release 10.0.0
+- Release 10.0.0
 * Fri May 21 2021 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
-    - Release 9.5.0
+- Release 9.5.0
 * Thu Aug 13 2020 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.0.0-1.0
-    - Release 9.0.0
+- Release 9.0.0
 * Mon Oct 21 2019 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 8.5.0-1.0
-    - Release 8.5.0
+- Release 8.5.0
 * Tue Apr 23 2019 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 8.1.0-1.0
-    - Release 8.1.0.
+- Release 8.1.0.
 * Wed Nov 07 2018 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 8.0.0-1.0
-    - Release 8.0.0.
+- Release 8.0.0.
 * Thu Mar 01 2018 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 7.5.0-1.0
-    - Release 7.5.0.
+- Release 7.5.0.
 * Thu Sep 21 2017 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 7.0.0-1.0
-    - Release 7.0.0.
+- Release 7.0.0.
 * Thu May 11 2017 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 6.6.0-1.0
-    - Release 6.6.0.
+- Release 6.6.0.
 * Tue Jan 10 2017 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 6.5.0-1.0
-    - Release 6.5.0.
+- Release 6.5.0.
 * Wed Sep 21 2016 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 6.0.0-1.0
-    - Release 6.0.0.
+- Release 6.0.0.
 * Tue May 24 2016 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 5.6.0-1.0
-    - Release 5.6.0.
+- Release 5.6.0.
 * Fri Dec 18 2015 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 5.5.0-1.0
-    - Release 5.5.0.
+- Release 5.5.0.
 * Wed Aug 19 2015 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 5.0.0-1.0
-    - Initial public release
+- Initial public release


### PR DESCRIPTION
Port of https://github.com/ubccr/xdmod-appkernels/pull/124 for the `main` branch.