### PR TITLE
Update docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
-## 2025-03-17 v11.0.1
-
-- Miscellaneous
-    - Updated for compatibility with Open XDMoD 11.0.1
-
 ## 2024-09-16 v11.0.0
 
 - Enhancements

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "name": "xdmod-appkernels",
-    "version": "11.0.1",
-    "release": "1",
+    "version": "11.0.0",
+    "release": "1.0",
     "files": {
         "include_paths": [
         ],

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -4,7 +4,7 @@ appkernels = "on"
 [appkernels-general]
 
 ; The version number is updated during the upgrade process.
-version = "11.0.1"
+version = "11.0.0"
 
 ; App kernel database and metric configuration.
 [appkernel]

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ defaults:
     values:
       layout: "page"
       version: "11.0"
-      sw_version: "11.0.1"
+      sw_version: "11.0.0"
       style: "effervescence"
       tocversion: "v11_0toc"
 

--- a/docs/ak-install-rpm.md
+++ b/docs/ak-install-rpm.md
@@ -5,7 +5,7 @@ title: Application Kernels RPM Installation Guide
 Install RPM Package
 -------------------
 
-    # dnf install xdmod-appkernels-{{ page.sw_version }}-1.el8.noarch.rpm
+    # dnf install xdmod-appkernels-{{ page.sw_version }}-1.0.el8.noarch.rpm
 
 Run Configuration Script
 ------------------------

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -65,8 +65,6 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 
 %changelog
-* Mon Mar 17 2025 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1
-- Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
 - Release 11.0.0
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0


### PR DESCRIPTION
This PR reverts the docs that mention 11.0.1 since there will be no 11.0.1 release for the `xdmod-appkernels` module. It also removes the OSes mentioned in the RPM installation instructions since we only support Rocky 8.