### PR TITLE
Fix duplicate file listed in spec file.

### DIFF
--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -61,7 +61,6 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/xdmod/setup.d/appkernels*.json
 %config(noreplace) %{_sysconfdir}/xdmod/rest.d/akrr.json
 %config(noreplace) %{_sysconfdir}/xdmod/rest.d/app_kernel.json
-%config(noreplace) %{_sysconfdir}/xdmod/linker.d/appkernels.json
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 
 %changelog


### PR DESCRIPTION
This PR fixes a file being listed twice in the spec file. When building RPMs, this fixes: `warning: File listed twice`.