### PR TITLE
Revert changes for 10.5.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 Open XDMoD Application Kernels Change Log
 =========================================
 
-## 2025-03-17 v10.5.1
-
-- Bug Fixes
-    - Fix PHP error when calculating control regions
-      ([\#128](https://github.com/ubccr/xdmod-appkernels/pull/128)).
-
 ## 2023-09-11 v10.5.0
 
 - Miscellaneous

--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod-appkernels",
-    "version": "10.5.1",
+    "version": "10.5.0",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/classes/AppKernel/AppKernelDb.php
+++ b/classes/AppKernel/AppKernelDb.php
@@ -2733,7 +2733,7 @@ class AppKernelDb
             $larger = true;
             $attr = explode(',', $metricAttribute);
 
-            if (isset($attr[2]) && strlen($attr[2]) > 0) {
+            if (isset($attr[2]) && count($attr[2]) > 0) {
                 $larger = substr($attr[2], 0, 1) != 'S';
             }
             if (isset($attr[1]) && $attr[1] !== '') {

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -4,7 +4,7 @@ appkernels = "on"
 [appkernels-general]
 
 ; The version number is updated during the upgrade process.
-version = "10.5.1"
+version = "10.5.0"
 
 ; App kernel database and metric configuration.
 [appkernel]

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ description: >
   week) to continuously monitor HPC system performance and reliability from the
   application users' point of view.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://appkernels.xdmod.org" # the base hostname & protocol for your site
+url: "http://appkernels.xdmod.org" # the base hostname & protocol for your site
 github_username: ubccr
 github_url: https://github.com/ubccr/xdmod-appkernels
 xdmod_module_name: Application Kernels
@@ -36,7 +36,7 @@ defaults:
     values:
       layout: "page"
       version: "10.5"
-      sw_version: "10.5.1"
+      sw_version: "10.5.0"
       style: "effervescence"
       tocversion: "toc"
 

--- a/xdmod-appkernels.spec.in
+++ b/xdmod-appkernels.spec.in
@@ -11,7 +11,7 @@ Source:        %{name}-%{version}__PRERELEASE__.tar.gz
 BuildRoot:     %(mktemp -ud %{_tmppath}/%{name}-%{version}__PRERELEASE__-%{release}-XXXXXX)
 BuildArch:     noarch
 BuildRequires: php-cli
-Requires:      xdmod >= 10.5.1, xdmod < 10.6.0
+Requires:      xdmod >= 10.5.0, xdmod < 10.6.0
 
 %description
 This package provides application kernel support for Open XDMoD. The
@@ -65,8 +65,6 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 
 %changelog
-* Mon Mar 17 2025 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.1-1.0
-- Release 10.5.1
 * Tue Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
 - Release 10.5.0
 * Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0


### PR DESCRIPTION
This PR reverts changes for 10.5.1. There will be no 10.5.1 release for `xdmod-appkernels`.