### PR TITLE
Update docs.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,6 +37,7 @@ defaults:
       layout: "page"
       version: "10.5"
       sw_version: "10.5.0"
+      rpm_version: "10.5.0-1.0"
       style: "effervescence"
       tocversion: "toc"
 

--- a/docs/ak-install-rpm.md
+++ b/docs/ak-install-rpm.md
@@ -5,7 +5,16 @@ title: Application Kernels RPM Installation Guide
 Install RPM Package
 -------------------
 
-    # yum install xdmod-appkernels-{{ page.sw_version }}-1.0.el7.noarch.rpm
+If your web server can reach GitHub via HTTPS, you can install the RPM package
+directly:
+
+    # dnf install https://github.com/ubccr/xdmod-appkernels/releases/download/v{{ page.rpm_version }}/xdmod-appkernels-{{ page.rpm_version }}.el8.noarch.rpm
+
+Otherwise, you can download the RPM file from the [GitHub page for the
+release](https://github.com/ubccr/xdmod-appkernels/releases/tag/v{{
+page.rpm_version }}) and install it:
+
+    # dnf install xdmod-appkernels-{{ page.rpm_version }}.el8.noarch.rpm
 
 Run Configuration Script
 ------------------------

--- a/docs/ak-install-source.md
+++ b/docs/ak-install-source.md
@@ -5,17 +5,22 @@ title: Application Kernels Source Installation Guide
 Install Source Package
 ----------------------
 
-    $ tar zxvf xdmod-appkernels-x.y.z.tar.gz
-    $ cd xdmod-appkernels-x.y.z
-    # ./install -prefix=/opt/xdmod
+The source package can be downloaded from
+[GitHub](https://github.com/ubccr/xdmod-appkernels/releases/tag/v{{ page.rpm_version }}).
+Make sure to download `xdmod-appkernels-{{ page.sw_version }}.tar.gz`, not the
+GitHub-generated "Source code" files.
 
 **NOTE**: The installation prefix must be the same as your existing Open
 XDMoD installation. These instructions assume you have already installed
-Open XDMoD in `/opt/xdmod`.
+Open XDMoD in `/opt/xdmod-{{ page.sw_version }}`.
+
+    # tar zxvf xdmod-appkernels-{{ page.sw_version }}.tar.gz
+    # cd xdmod-appkernels-{{ page.sw_version }}
+    # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 ### Copy Configuration Files
 
-    # cp /opt/xdmod/etc/cron.d/xdmod-appkernels /etc/cron.d/xdmod-appkernels
+    # cp /opt/xdmod-{{ page.sw_version }}/etc/cron.d/xdmod-appkernels /etc/cron.d/xdmod-appkernels
 
 The directory where this file is needed may differ depending on your
 operating system.
@@ -23,7 +28,7 @@ operating system.
 Run Configuration Script
 ------------------------
 
-    # /opt/xdmod/bin/xdmod-setup
+    # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-setup
 
 There should be a new section titled "Application Kernels" in the list.
 Select that option and provide the required information.  Specifically,
@@ -31,7 +36,7 @@ you will need to enter database credentials to access the databases
 created by AKRR and the AKRR REST API credentials.
 
 **NOTE**: It is also possible to manually modify
-`/opt/xdmod/etc/portal_settings.d/appkernels.ini`.
+`/opt/xdmod-{{ page.sw_version }}/etc/portal_settings.d/appkernels.ini`.
 
 Ingest Data From AKRR
 ---------------------
@@ -39,7 +44,7 @@ Ingest Data From AKRR
 If one or more jobs have been submitted by AKRR and completed, you may
 ingest that data:
 
-    $ /opt/xdmod/bin/xdmod-akrr-ingestor -v -l load
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-akrr-ingestor -v -l load
 
 See the [Application Kernels Ingestor Guide](ak-ingestor.html) for more
 details.

--- a/docs/ak-upgrade.md
+++ b/docs/ak-upgrade.md
@@ -1,0 +1,14 @@
+---
+title: Application Kernels Upgrade Guide
+---
+
+General Upgrade Notes
+---------------------
+
+The Open XDMoD Application Kernels module should be upgraded at the same time
+as the main Open XDMoD software. The upgrade procedure is documented on the
+[Open XDMoD upgrade page](https://open.xdmod.org/upgrade.html). Downloads of
+RPMs and source packages for the Open XDMoD Application Kernels module are
+available from [GitHub][github-release].
+
+[github-release]: https://github.com/ubccr/xdmod-appkernels/releases/tag/v{{ page.rpm_version }}


### PR DESCRIPTION
Backport of https://github.com/ubccr/xdmod-appkernels/pull/135 for the `xdmod10.5` branch.