### PR TITLE
Fix a few bugs due to PHP7

### DIFF
--- a/classes/DataWarehouse/Access/DataExplorer.php
+++ b/classes/DataWarehouse/Access/DataExplorer.php
@@ -124,7 +124,7 @@ class DataExplorer extends Common
             $chart->setTitle($show_title?($title):NULL, $font_size);
             $chart->setLegend($legend_location, $font_size);//called before and after
             $show_closest_hover_label = count($datasets) > 1;
-            $chart->configure($datasets,
+            $chart->configureAppKernelChart($datasets,
                 $font_size,
                 $limit,
                 $offset,

--- a/classes/DataWarehouse/Visualization/AppKernelChart.php
+++ b/classes/DataWarehouse/Visualization/AppKernelChart.php
@@ -1012,7 +1012,6 @@ class AppKernelChart extends AggregateChart
             $scale = $this->_swapXY ? $this->_chart['layout']['xaxis']['range'][1] : $this->_chart['layout']['yaxis']['range'][1];
             $this->_chart['layout']['images'][$i]['sizey'] = max($scale * 0.025, 1);
         }
-        $this->_chart['data'] = array_reverse($this->_chart['data']); // Put data traces on top of 'Control Bands'
         $this->setDataSource(array('XDMoD App Kernels'));
     }
 

--- a/classes/DataWarehouse/Visualization/AppKernelChart.php
+++ b/classes/DataWarehouse/Visualization/AppKernelChart.php
@@ -470,7 +470,7 @@ class AppKernelChart extends AggregateChart
                     );
                 }
 
-                $aColor = '#'.str_pad(dechex(\DataWarehouse\Visualization::alterBrightness($color, -200)), 6, '0', STR_PAD_LEFT);
+                $aColor = '#'.str_pad(dechex(\DataWarehouse\Visualization::alterBrightness($color_value, -200)), 6, '0', STR_PAD_LEFT);
                 $average_trace = array_merge($trace, array(
                     'name' => 'Running Average',
                     'zIndex' => 8,
@@ -1012,6 +1012,7 @@ class AppKernelChart extends AggregateChart
             $scale = $this->_swapXY ? $this->_chart['layout']['xaxis']['range'][1] : $this->_chart['layout']['yaxis']['range'][1];
             $this->_chart['layout']['images'][$i]['sizey'] = max($scale * 0.025, 1);
         }
+        $this->_chart['data'] = array_reverse($this->_chart['data']); // Put data traces on top of 'Control Bands'
         $this->setDataSource(array('XDMoD App Kernels'));
     }
 

--- a/classes/DataWarehouse/Visualization/AppKernelChart.php
+++ b/classes/DataWarehouse/Visualization/AppKernelChart.php
@@ -55,7 +55,7 @@ class AppKernelChart extends AggregateChart
         $this->_indicator_url = '/gui/images/exclamation_ak.png';
     }
 
-    public function configure(
+    public function configureAppKernelChart(
         &$datasets,
         $font_size = 0,
         $limit = null,

--- a/classes/Rest/Controllers/AppKernelControllerProvider.php
+++ b/classes/Rest/Controllers/AppKernelControllerProvider.php
@@ -500,7 +500,7 @@ class AppKernelControllerProvider extends BaseControllerProvider
         $chart->setLegend($legend_location, $font_size);
 
         $datasets = array();
-        $chart->configure(
+        $chart->configureAppKernelChart(
             $datasets,
             $font_size,
             $limit,
@@ -579,7 +579,7 @@ class AppKernelControllerProvider extends BaseControllerProvider
 
             if ($format != 'params') {
                 $datasets = array($result);
-                $chart->configure(
+                $chart->configureAppKernelChart(
                     $datasets,
                     $font_size,
                     $limit,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- PHP only supports overloading 'magic' methods so I decided to just renamed the App Kernels configure because it is quite different than the base `configure()`.
- The call to `alterBrighteness()` should have used `$color_value` from the start. [PHP7 changes](https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.strings.hex) exposes this due to making string hexadecimal a non-numeric type.

<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
App kernel charts were inaccessible before these changes. Loading a chart would throw an exception with a message '200'.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
On xdmod dev
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
